### PR TITLE
Adjusted missing get_ipsecifnum mitigation

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -670,10 +670,10 @@ function pfz_ipsec_status($ikeid,$reqid=-1,$valuekey='state'){
             } else {
                 $cname = "con{$ph1ent['ikeid']}00000";
             }
-            $conmap[$cname] = $ph1ent['ikeid'];
         } else{
             $cname = ipsec_conid($ph1ent);
         }
+	    $conmap[$cname] = $ph1ent['ikeid'];
 	}
 
 	$status = ipsec_list_sa();


### PR DESCRIPTION
$conmap was not updated if get_ipsecifnum is missing.